### PR TITLE
Switch build target to browser and bump version to 2.1.1

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -4,7 +4,7 @@ import isolatedDecl from 'bun-plugin-isolated-decl';
 await Bun.build({
   entrypoints: ['./src/index.ts', './src/types.ts'],
   outdir: './dist',
-  target: 'node',
+  target: 'browser',
   plugins: [
     isolatedDecl({
       forceGenerate: true,  // Generate declaration files even if there are errors

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifold-workflow-engine",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "seemueller-io",
   "type": "module",
   "description": "for building dynamic, LLM-driven workflows using a region-based execution model",


### PR DESCRIPTION
Updated the build target from Node to browser in `build.ts` to support browser environments. Incremented the package version from 2.1.0 to 2.1.1 to reflect the change.